### PR TITLE
🤭 Make create-react-class and prop-types external modules 🤫

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,8 @@ if (TARGET === 'build') {
     externals: {
       "react": "umd react",
       "react-dom": "umd react-dom",
+      "create-react-class": "umd create-react-class",
+      "prop-types": "umd prop-types",
       "mobiledoc-kit": "umd mobiledoc-kit"
     },
     plugins: [


### PR DESCRIPTION
In #11, we added support for React 16. As part of that upgrade, we were required to import two new npm packages to maintain backwards compatibility: create-react-class and prop-types.

Because react-mobiledoc-editor is compiled for distribution using webpack, any dependencies will be “inlined” into the final output unless they are explicitly marked in the webpack config as external.

I forgot to make these two new dependencies external. This caused react-mobiledoc-editor to inline its own copies of these two packages instead of loading them from node_modules at runtime.

This is problematic for a number of reasons, but one of the most obvious is that it meant that create-react-class was running in production mode while end users were probably running React in development mode. This manifested itself as spurious warning messages about getDefaultProps being deprecated, which is in fact still supported by create-react-class.

Fixes #12