### PR TITLE
Fix UMD Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --mode development --hot --progress",
     "lint": "eslint src",
-    "test": "karma start --single-run",
+    "test": "karma start --single-run && npm run test:build",
     "test:watch": "karma start",
     "test:build": "yarn build && mocha test/build",
     "posttest": "yarn lint",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint src",
     "test": "karma start --single-run",
     "test:watch": "karma start",
+    "test:build": "yarn build && mocha test/build",
     "posttest": "yarn lint",
     "build": "rm -rf ./dist && webpack --mode production",
     "prepublish": "yarn build"

--- a/test/build/index.js
+++ b/test/build/index.js
@@ -1,0 +1,8 @@
+const { ReactMobiledocEditor } = require('../../dist/main');
+const { expect } = require('chai');
+
+describe('build', () => {
+  it('should build UMD compliant output', () => {
+    expect(ReactMobiledocEditor).to.be.ok;
+  });
+});

--- a/test/build/index.js
+++ b/test/build/index.js
@@ -1,8 +1,8 @@
-const { ReactMobiledocEditor } = require('../../dist/main');
+const ReactMobiledocEditor = require('../../dist/main');
 const { expect } = require('chai');
 
 describe('build', () => {
   it('should build UMD compliant output', () => {
-    expect(ReactMobiledocEditor).to.be.ok;
+    expect(ReactMobiledocEditor).to.be.an('object');
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,8 @@ var config = {
   output: {
     library: 'ReactMobiledocEditor',
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: `typeof self !== 'undefined' ? self : this`
   },
   module: {
     rules: [


### PR DESCRIPTION
There is a bug in a recent version of webpack that prevents the output from being used in node:
https://github.com/webpack/webpack/issues/6784

This adds a test for the build and applies a fix to the webpack config.  When webpack fixes the bug, you could remove the fix.

Closes https://github.com/joshfrench/react-mobiledoc-editor/issues/16