### PR TITLE
classToAtom React Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,6 @@ mobiledoc-specific props:
   update the payload as it exists in the mobiledoc, use the `save` callback.
 - `save`: A callback which accepts a new payload for the card, then saves that
   value and payload to the underlying mobiledoc.
-- `cancel`: A callback for toggling this card to display mode without saving (a
-  no-op if the card is already in display mode).
-- `remove`: A callback for removing this card entirely.
 - `name`: The name of this card.
 - `onTeardown`: A callback that can be called when the rendered content is torn down.
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ class MyComponent extends React.Component<Props> {
   handleClick = () => {
     let {payload, save, value} = this.props;
     let clicks = (payload.clicks || 0) + 1;
-    save(value, {...payload, clicks});
+    save(value, {...payload, clicks}); // updates payload.clicks, rerenders button
   };
 
   render() {

--- a/README.md
+++ b/README.md
@@ -285,19 +285,11 @@ import { classToDOMAtom } from 'react-mobiledoc-editor';
 class MyComponent extends React.Component<Props> {
   static displayName = 'MyComponent';
 
-  handleClick = () => {
-    let {payload, save, value} = this.props;
-    let clicks = (payload.clicks || 0) + 1;
-    save(value, {...payload, clicks}); // updates payload.clicks, rerenders button
-  };
-
   render() {
-    let { payload } = this.props;
+    let { value } = this.props;
 
     return (
-      <button onClick={this.handleClick}>
-        Clicks: {payload.clicks || 0}
-      </button>
+      @{value}
     );
   }
 }
@@ -334,7 +326,7 @@ house style, but the linter can be run independently with `npm run lint`.
 
 #### Running the Demo
 
-A small demo of basic usage and simple card integration is available under the
+A small demo of basic usage and simple card and atom integration is available under the
 `/demo` directory. To start the demo server, run `npm start` from the project
 root.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ import { Component } from 'react';
 import { classToDOMCard } from 'react-mobiledoc-editor';
 
 class MyComponent extends Component {
+  static displayName = 'MyComponent'
+
   render() {
     let { isInEditor } = this.props;
     let text = isInEditor ? "This is the editable interface"
@@ -234,7 +236,6 @@ class MyComponent extends Component {
     return <p>{text}</p>;
   }
 }
-MyComponent.displayName = 'MyComponent';
 
 const MyComponentCard = classToDOMCard(MyComponent);
 ```
@@ -266,6 +267,65 @@ mobiledoc-specific props:
 - `isInEditor`: A bool indicating if the card is displayed inside an editor
   interface or not.
 - `isEditing`: A bool indicating if the card is in Edit mode or not.
+
+## Component-based Atoms
+
+As stated in the [Mobiledoc Atom Documentation](https://github.com/bustle/mobiledoc-kit/blob/master/ATOMS.md), "Atoms are effectively read-only inline cards." They are sections of rich content that only spans the space of a word or a sentence within a paragraph. The common example is an `@` mention within a block of text.
+
+`react-mobiledoc-editor` comes with a helper for using your own React
+components as the display and update the content of an Atom.
+
+To wrap your own component in the Atom interface, simply call `classToDOMAtom`
+on it:
+
+```jsx
+import { Component } from 'react';
+import { classToDOMAtom } from 'react-mobiledoc-editor';
+
+class MyComponent extends React.Component<Props> {
+  static displayName = 'MyComponent';
+
+  handleClick = () => {
+    let {payload, save, value} = this.props;
+    let clicks = (payload.clicks || 0) + 1;
+    save(value, {...payload, clicks});
+  };
+
+  render() {
+    let { payload } = this.props;
+
+    return (
+      <button onClick={this.handleClick}>
+        Clicks: {payload.clicks || 0}
+      </button>
+    );
+  }
+}
+
+const MyComponentAtom = classToDOMAtom(MyComponent);
+```
+
+As with Cards, note that your component MUST implement `displayName`. This is so the
+editor and other mobiledoc consumers can identify your custom atoms.
+
+Once your components have been wrapped in the atom interface, they should be
+passed to the Mobiledoc [`<Container>`](https://github.com/joshfrench/react-mobiledoc-editor#container) component via the `atoms` prop.
+
+Atom-based components will be instantiated with the following
+mobiledoc-specific props:
+
+- `value`: The textual representation to for this atom.
+- `payload`: The payload for this atom. Please note the payload object is
+  disconnected from the atom's representation in the serialized mobiledoc; to
+  update the payload as it exists in the mobiledoc, use the `save` callback.
+- `save`: A callback which accepts a new payload for the card, then saves that
+  value and payload to the underlying mobiledoc.
+- `cancel`: A callback for toggling this card to display mode without saving (a
+  no-op if the card is already in display mode).
+- `remove`: A callback for removing this card entirely.
+- `name`: The name of this card.
+- `onTeardown`: A callback that can be called when the rendered content is torn down.
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ As stated in the [Mobiledoc Atom Documentation](https://github.com/bustle/mobile
 components as the display and update the content of an Atom.
 
 To wrap your own component in the Atom interface, simply call `classToDOMAtom`
-on it:
+on it. This example illustrates an Atom component which renders a button and saves the click count to the underlying mobiledoc:
 
 ```jsx
 import { Component } from 'react';

--- a/demo/ClickCounterAtom.js
+++ b/demo/ClickCounterAtom.js
@@ -1,0 +1,39 @@
+import createReactClass from 'create-react-class';
+import React from 'react';
+import { classToDOMAtom } from '../src';
+
+/**
+ * Component-based atoms are rendered with these props:
+ *
+ * - `value`: The textual representation to for this atom.
+ * - `payload`: The payload for this atom. Please note the payload object is
+ *    disconnected from the atom's representation in the serialized mobiledoc; to
+ *    update the payload as it exists in the mobiledoc, use the `save` callback.
+ * - `save`: A callback which accepts a new payload for the card, then saves that
+ *    value and payload to the underlying mobiledoc.
+ * - `name`: The name of this card.
+ * - `onTeardown`: A callback that can be called when the rendered content is torn down.
+ */
+const Counter = createReactClass({
+  displayName: 'Counter',
+
+  handleClick: () => {
+    const { payload, save, value } = this.props;
+    const clicks = (payload.clicks || 0) + 1;
+    save(value, { ...payload, clicks }); // updates payload.clicks, rerenders button
+  },
+
+  render() {
+    const { payload } = this.props;
+
+    return (
+      <button onClick={this.handleClick}>
+        Clicks: {payload.clicks || 0}
+      </button>
+    );
+  }
+});
+
+const ClickCounterAtom = classToDOMAtom(Counter);
+
+export default ClickCounterAtom;

--- a/demo/ClickCounterAtom.js
+++ b/demo/ClickCounterAtom.js
@@ -14,10 +14,12 @@ import { classToDOMAtom } from '../src';
  * - `name`: The name of this card.
  * - `onTeardown`: A callback that can be called when the rendered content is torn down.
  */
+
+
 const Counter = createReactClass({
   displayName: 'Counter',
 
-  handleClick: () => {
+  handleClick: function() {
     const { payload, save, value } = this.props;
     const clicks = (payload.clicks || 0) + 1;
     save(value, { ...payload, clicks }); // updates payload.clicks, rerenders button

--- a/demo/index.js
+++ b/demo/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 
 import * as ReactMobiledoc from '../src';
 import ImageCard from './ImageCard';
+import ClickCounterAtom from './ClickCounterAtom';
 
 const mobiledoc = {
   version: "0.3.0",
@@ -21,6 +22,7 @@ const onChange = (doc) => { console.log(doc); };
 const config = {
   mobiledoc,
   cards: [ImageCard],
+  atoms: [ClickCounterAtom],
   placeholder: "Welcome to Mobiledoc!",
   willCreateEditor,
   didCreateEditor,
@@ -34,6 +36,12 @@ const ImageButton = ({ isEditing = true }, { editor }) => {
   return <button onClick={onClick}>Image</button>;
 };
 
+const ClickCounterButton = ({ isEditing = true }, { editor }) => {
+  console.log(arguments);
+  const onClick = () => editor.insertAtom('Counter', '', { count: 0 });
+  return <button onClick={onClick}>Click Counter</button>;
+};
+
 ImageButton.contextTypes = {
   editor: PropTypes.object
 };
@@ -41,6 +49,7 @@ ImageButton.contextTypes = {
 ReactDOM.render(<ReactMobiledoc.Container {...config}>
                   <ReactMobiledoc.Toolbar />
                   <ImageButton />
+                  <ClickCounterButton />
                   <ReactMobiledoc.Editor />
                 </ReactMobiledoc.Container>,
                 document.getElementById('root'));

--- a/demo/index.js
+++ b/demo/index.js
@@ -31,20 +31,31 @@ const config = {
 
 const imgPayload = { caption: "Edit this right meow!", src: "http://www.placekitten.com/200/200" };
 
-const ImageButton = ({ isEditing = true }, { editor }) => {
-  const onClick = () => editor.insertCard('ImageCard', imgPayload, isEditing);
-  return <button onClick={onClick}>Image</button>;
-};
 
-const ClickCounterButton = ({ isEditing = true }, { editor }) => {
-  console.log(arguments);
-  const onClick = () => editor.insertAtom('Counter', '', { count: 0 });
-  return <button onClick={onClick}>Click Counter</button>;
+const ImageButton = (props, context) => {
+  const { isEditing } = props;
+  const { editor } = context;
+
+  const onClick = () => editor.insertCard('ImageCard', imgPayload, isEditing);
+  return <button onClick={onClick}>Image Card</button>;
 };
 
 ImageButton.contextTypes = {
   editor: PropTypes.object
 };
+
+
+const ClickCounterButton = (props, context) => {
+  const { editor } = context;
+  const onClick = () => editor.insertAtom('Counter', '', { count: 0 });
+  return <button onClick={onClick}>Click Counter Atom</button>;
+};
+
+ClickCounterButton.contextTypes = {
+  editor: PropTypes.object
+};
+
+
 
 ReactDOM.render(<ReactMobiledoc.Container {...config}>
                   <ReactMobiledoc.Toolbar />

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { classToDOMCard } from './utils/classToCard';
+import { classToDOMAtom } from './utils/classToAtom';
 import Container, { EMPTY_MOBILEDOC } from './components/Container';
 import Editor from './components/Editor';
 import LinkButton from './components/LinkButton';
@@ -9,6 +10,7 @@ import Toolbar from './components/Toolbar';
 
 export {
   classToDOMCard,
+  classToDOMAtom,
   Container,
   Editor,
   EMPTY_MOBILEDOC,

--- a/src/utils/classToAtom.js
+++ b/src/utils/classToAtom.js
@@ -1,0 +1,31 @@
+const atomRenderer = (component) => ({env, options, payload}) => {
+  const {onTeardown} = env;
+
+  const element = React.createElement(component, {
+    ...env,
+    ...options,
+    payload: {...payload}
+  });
+
+  const targetNode = document.createElement('span');
+  ReactDOM.render(element, targetNode);
+
+  onTeardown(() => ReactDOM.unmountComponentAtNode(targetNode));
+
+  return targetNode;
+};
+
+export const classToDOMAtom = (component) => {
+  if (!component.displayName) {
+    throw new Error(
+      `Can't create card from component, no displayName defined:  + ${component}`
+    );
+  }
+
+  return {
+    name: component.displayName,
+    component,
+    type: 'dom',
+    render: atomRenderer(component)
+  };
+};

--- a/src/utils/classToAtom.js
+++ b/src/utils/classToAtom.js
@@ -22,7 +22,7 @@ const atomRenderer = (component) => ({ env, options, payload, value }) => {
 export const classToDOMAtom = (component) => {
   if (!component.displayName) {
     throw new Error(
-      `Can't create atom from component, no displayName defined:  + ${component}`
+      `Can't create atom from component, no displayName defined: ${component}`
     );
   }
 

--- a/src/utils/classToAtom.js
+++ b/src/utils/classToAtom.js
@@ -1,9 +1,13 @@
-const atomRenderer = (component) => ({env, options, payload}) => {
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const atomRenderer = (component) => ({env, options, payload, value}) => {
   const {onTeardown} = env;
 
   const element = React.createElement(component, {
     ...env,
     ...options,
+    value,
     payload: {...payload}
   });
 

--- a/src/utils/classToAtom.js
+++ b/src/utils/classToAtom.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-const atomRenderer = (component) => ({env, options, payload, value}) => {
-  const {onTeardown} = env;
+const atomRenderer = (component) => ({ env, options, payload, value }) => {
+  const { onTeardown } = env;
 
   const element = React.createElement(component, {
     ...env,
     ...options,
     value,
-    payload: {...payload}
+    payload: { ...payload }
   });
 
   const targetNode = document.createElement('span');

--- a/src/utils/classToAtom.js
+++ b/src/utils/classToAtom.js
@@ -18,7 +18,7 @@ const atomRenderer = (component) => ({env, options, payload}) => {
 export const classToDOMAtom = (component) => {
   if (!component.displayName) {
     throw new Error(
-      `Can't create card from component, no displayName defined:  + ${component}`
+      `Can't create atom from component, no displayName defined:  + ${component}`
     );
   }
 

--- a/test/utils/classToAtomTest.js
+++ b/test/utils/classToAtomTest.js
@@ -1,0 +1,13 @@
+import { classToDOMAtom } from '../../src/utils/classToAtom';
+import { expect } from 'chai';
+
+describe('classToDOMAtom()', () => {
+  it('should infer name from component displayName', () => {
+    const atom = classToDOMAtom({ displayName: "Test" });
+    expect(atom.name).to.eql('Test');
+  });
+
+  it('should raise if no displayName is set', () => {
+    expect(() => classToDOMAtom({  })).to.throw(/no displayName defined/);
+  });
+});


### PR DESCRIPTION
Adds support for classToAtom helper function, modeled after the existing `classToCard`.

I'm also happy to add documentation to the README if @joshfrench approves of including this in the repo.