### PR TITLE
Only use EMPTY_MOBILEDOC if no html is passed.

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -67,8 +67,14 @@ const Container = createReactClass({
       this.props.willCreateEditor();
     }
 
-    const mobiledoc = this.props.mobiledoc || EMPTY_MOBILEDOC;
+
+    let mobiledoc = this.props.mobiledoc;
     const { atoms, autofocus, cardProps, cards, html, placeholder, serializeVersion, spellcheck } = this.props;
+
+    if (! mobiledoc && ! html) {
+      mobiledoc = EMPTY_MOBILEDOC;
+    }
+
     const editorOptions = { ...this.props.options, atoms, autofocus, cardOptions: { cardProps }, cards, html, mobiledoc, placeholder, serializeVersion, spellcheck };
     this.editor = new Mobiledoc.Editor(editorOptions);
 

--- a/test/components/ContainerTest.js
+++ b/test/components/ContainerTest.js
@@ -50,6 +50,13 @@ describe('<Container />', () => {
     expect(wrapper.instance().editor.html).to.equal(html);
   });
 
+  it('should not pass empty mobiledoc to the editor if html is passed', () => {
+    const html = '<p>Ohai</p>';
+
+    const wrapper = mount(<Container html={html} />);
+    expect(wrapper.instance().editor.mobiledoc).to.be.undefined;
+  });
+
   it('should pass placeholder to editor', () => {
     const wrapper = mount(<Container placeholder="placeholder!" />);
     expect(wrapper.instance().editor.placeholder).to.equal('placeholder!');


### PR DESCRIPTION
Fixes #29.