### PR TITLE
Support latest mobiledoc-kit version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "mobiledoc-kit": "^0.10.11",
+    "mobiledoc-kit": "^0.10.11 || ^0.11.0",
     "react": "^0.14.7 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.7 || ^15.0.0 || ^16.0.0"
   },


### PR DESCRIPTION
Fixes warning:
`npm WARN react-mobiledoc-editor@0.6.0 requires a peer of mobiledoc-kit@^0.10.11 but none is installed. You must install peer dependencies yourself.`