### PR TITLE
Use npm for scripts instead of yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "lint": "eslint src",
     "test": "karma start --single-run && npm run test:build",
     "test:watch": "karma start",
-    "test:build": "yarn build && mocha test/build",
-    "posttest": "yarn lint",
+    "test:build": "npm run build && mocha test/build",
+    "posttest": "npm run lint",
     "build": "rm -rf ./dist && webpack --mode production",
-    "prepublish": "yarn build"
+    "prepublish": "npm run build"
   },
   "dependencies": {
     "classnames": "^2.2.5",


### PR DESCRIPTION
Looks like development supports yarn or npm based on the presence of both lock files.  

Anyone who has yarn also has npm but not the other way around, so use npm to invoke the package.json scripts