### PR TITLE
Support latest mobiledoc version & autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ The `Container` component accepts these Mobiledoc-specific props:
 - `options`: A hash of additional options that will be passed through to the
   Mobiledoc editor constructor.
 - `serializeVersion`: A string representing the mobiledoc version to serialize
-  to when firing the `onChange` action. Defaults to `0.3.0`.
+  to when firing the `onChange` action. Defaults to the latest version from
+  mobiledoc-kit (`0.3.1`).
 - `onChange`: A callback that will fire whenever the underlying document
   changes. Use this to persist and/or serialize your mobiledoc to another
   format as it's being edited. Will be called with the serialized mobiledoc.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ The `Container` component accepts these Mobiledoc-specific props:
 - `options`: A hash of additional options that will be passed through to the
   Mobiledoc editor constructor.
 - `serializeVersion`: A string representing the mobiledoc version to serialize
-  to when firing the `onChange` action. Defaults to the latest version from
-  mobiledoc-kit (`0.3.1`).
+  to when firing the `onChange` action. Defaults to `0.3.1`.
 - `onChange`: A callback that will fire whenever the underlying document
   changes. Use this to persist and/or serialize your mobiledoc to another
   format as it's being edited. Will be called with the serialized mobiledoc.

--- a/demo/index.js
+++ b/demo/index.js
@@ -6,27 +6,15 @@ import * as ReactMobiledoc from '../src';
 import ImageCard from './ImageCard';
 import ClickCounterAtom from './ClickCounterAtom';
 
-const mobiledoc = {
-  version: "0.3.0",
-  markups: [],
-  atoms: [],
-  cards: [],
-  sections: [
-  ]
-};
-
-const willCreateEditor = () => { console.log('creating editor...'); };
-const didCreateEditor = (e) => { console.log('created editor:', e); };
-const onChange = (doc) => { console.log(doc); };
 
 const config = {
-  mobiledoc,
   cards: [ImageCard],
   atoms: [ClickCounterAtom],
   placeholder: "Welcome to Mobiledoc!",
-  willCreateEditor,
-  didCreateEditor,
-  onChange
+  willCreateEditor:() => { console.log('creating editor...'); },
+  didCreateEditor:(e) => { console.log('created editor:', e); },
+  onChange:(doc) => { console.log(doc); },
+  autoFocus: true
 };
 
 const imgPayload = { caption: "Edit this right meow!", src: "http://www.placekitten.com/200/200" };

--- a/demo/index.js
+++ b/demo/index.js
@@ -13,8 +13,7 @@ const config = {
   placeholder: "Welcome to Mobiledoc!",
   willCreateEditor:() => { console.log('creating editor...'); },
   didCreateEditor:(e) => { console.log('created editor:', e); },
-  onChange:(doc) => { console.log(doc); },
-  autoFocus: true
+  onChange:(doc) => { console.log(doc); }
 };
 
 const imgPayload = { caption: "Edit this right meow!", src: "http://www.placekitten.com/200/200" };

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -2,14 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Mobiledoc from 'mobiledoc-kit';
-
-export const EMPTY_MOBILEDOC = {
-  version: "0.3.0",
-  markups: [],
-  atoms: [],
-  cards: [],
-  sections: []
-};
+import { LATEST_MOBILEDOC_VERSION, EMPTY_MOBILEDOC } from '../utils/mobiledoc';
 
 const Container = createReactClass({
   displayName: 'Container',
@@ -42,7 +35,7 @@ const Container = createReactClass({
       cardProps: {},
       cards: [],
       placeholder: "",
-      serializeVersion: "0.3.0",
+      serializeVersion: LATEST_MOBILEDOC_VERSION,
       spellcheck: true
     };
   },
@@ -67,13 +60,8 @@ const Container = createReactClass({
       this.props.willCreateEditor();
     }
 
-
-    let mobiledoc = this.props.mobiledoc;
     const { atoms, autofocus, cardProps, cards, html, placeholder, serializeVersion, spellcheck } = this.props;
-
-    if (! mobiledoc && ! html) {
-      mobiledoc = EMPTY_MOBILEDOC;
-    }
+    const mobiledoc = this.props.mobiledoc || (html ? undefined : EMPTY_MOBILEDOC);
 
     const editorOptions = { ...this.props.options, atoms, autofocus, cardOptions: { cardProps }, cards, html, mobiledoc, placeholder, serializeVersion, spellcheck };
     this.editor = new Mobiledoc.Editor(editorOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { classToDOMCard } from './utils/classToCard';
 import { classToDOMAtom } from './utils/classToAtom';
-import Container, { EMPTY_MOBILEDOC } from './components/Container';
+import { EMPTY_MOBILEDOC } from './utils/mobiledoc';
+import Container from './components/Container';
 import Editor from './components/Editor';
 import LinkButton from './components/LinkButton';
 import MarkupButton from './components/MarkupButton';
@@ -11,9 +12,9 @@ import Toolbar from './components/Toolbar';
 export {
   classToDOMCard,
   classToDOMAtom,
+  EMPTY_MOBILEDOC,
   Container,
   Editor,
-  EMPTY_MOBILEDOC,
   LinkButton,
   MarkupButton,
   SectionButton,

--- a/src/utils/mobiledoc.js
+++ b/src/utils/mobiledoc.js
@@ -1,0 +1,11 @@
+export const LATEST_MOBILEDOC_VERSION = require('mobiledoc-kit/dist/commonjs/mobiledoc-kit/renderers/mobiledoc').MOBILEDOC_VERSION;
+
+export const EMPTY_MOBILEDOC = {
+  version: LATEST_MOBILEDOC_VERSION,
+  markups: [],
+  atoms: [],
+  cards: [],
+  sections: [
+    [1, "p", []]
+  ]
+};

--- a/src/utils/mobiledoc.js
+++ b/src/utils/mobiledoc.js
@@ -1,4 +1,4 @@
-export const LATEST_MOBILEDOC_VERSION = require('mobiledoc-kit/dist/commonjs/mobiledoc-kit/renderers/mobiledoc').MOBILEDOC_VERSION;
+export const LATEST_MOBILEDOC_VERSION = "0.3.1";
 
 export const EMPTY_MOBILEDOC = {
   version: LATEST_MOBILEDOC_VERSION,

--- a/test/components/ContainerTest.js
+++ b/test/components/ContainerTest.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Container from '../../src/components/Container';
 import Editor from '../../src/components/Editor';
 import { classToDOMCard } from '../../src/utils/classToCard';
+import { LATEST_MOBILEDOC_VERSION } from '../../src/utils/mobiledoc';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { shallow, mount } from 'enzyme';
@@ -28,7 +29,7 @@ describe('<Container />', () => {
 
   it('should pass mobiledoc to editor', () => {
     const doc = {
-      version: "0.3.0",
+      version: "0.3.1",
       markups: [],
       atoms: [],
       cards: [],
@@ -92,7 +93,7 @@ describe('<Container />', () => {
       const section = postEditor.builder.createMarkupSection('p');
       postEditor.insertSection(section);
     });
-    expect(onChange).to.have.been.calledWithMatch({ version: "0.3.0" });
+    expect(onChange).to.have.been.calledWithMatch({ version: LATEST_MOBILEDOC_VERSION });
 
     wrapper = mount(<Container serializeVersion="0.2.0" onChange={onChange}><Editor /></Container>);
     editor = wrapper.instance().editor;
@@ -141,7 +142,7 @@ describe('<Container />', () => {
     const PropCard = classToDOMCard(Prop);
 
     const doc = {
-      version: '0.3.0',
+      version: '0.3.1',
       atoms: [],
       cards: [['PropCard', {}]],
       markups: [],


### PR DESCRIPTION
Serialize and create using the latest version of mobiledoc (0.3.1).

Fixes autofocus not working because EMPTY_MOBILEDOC needs an empty section.
Closes #14