### PR TITLE
Version bump: 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mobiledoc-editor",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mobiledoc-editor",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A Mobiledoc editor for React apps",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
- Support latest mobiledoc-kit version in peerDependencies
- New documents are now created with the latest mobiledoc document version
- Upgrade dependencies
- [bugfix] Autofocus now working
- [bugfix] Only use EMPTY_MOBILEDOC if no html is passed

@joshfrench can you npm publish after this is merged (or give me npm access? user: gdub) Thanks!