### PR TITLE
Remove classnames dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2128,11 +2128,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "classnames": "^2.2.6",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/src/components/LinkButton.js
+++ b/src/components/LinkButton.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 import { UI } from 'mobiledoc-kit';
 
 const LinkButton = ({ children = "Link", type = "button", handler, className, activeClassName = 'active', ...props }, { editor, activeMarkupTags = []}) => {
@@ -16,9 +15,7 @@ const LinkButton = ({ children = "Link", type = "button", handler, className, ac
     }
   };
 
-  className = classNames(className, {
-    [activeClassName]: activeMarkupTags.indexOf('a') > -1
-  });
+  className = [className, activeMarkupTags.indexOf('a') > -1 && activeClassName].filter(Boolean).join(' ');
 
   props = { type, ...props, onClick, className };
   return <button { ...props }>{children}</button>;

--- a/src/components/MarkupButton.js
+++ b/src/components/MarkupButton.js
@@ -1,13 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 import titleCase from '../utils/titleCase';
 
 const MarkupButton = ({ tag = '', type = 'button', children = titleCase(tag), className, activeClassName = 'active', ...props }, { editor, activeMarkupTags = []}) => {
   const onClick = () => editor.toggleMarkup(tag);
-  className = classNames(className, {
-    [activeClassName]: activeMarkupTags.indexOf(tag.toLowerCase()) > -1
-  });
+  className = [className, activeMarkupTags.indexOf(tag.toLowerCase()) > -1 && activeClassName].filter(Boolean).join(' ');
   props = { type, ...props, onClick, className };
   return <button { ...props }>{children}</button>;
 };

--- a/src/components/SectionButton.js
+++ b/src/components/SectionButton.js
@@ -1,13 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 import titleCase from '../utils/titleCase';
 
 const SectionButton = ({ tag = '', type = 'button', children = titleCase(tag), className, activeClassName = 'active', ...props }, { editor, activeSectionTags = []}) => {
   const onClick = () => editor.toggleSection(tag);
-  className = classNames(className, {
-    [activeClassName]: activeSectionTags.indexOf(tag.toLowerCase()) > -1
-  });
+  className = [className, activeSectionTags.indexOf(tag.toLowerCase()) > -1 && activeClassName].filter(Boolean).join(' ');
   props = { type, ...props, onClick, className };
   return <button { ...props }>{children}</button>;
 };

--- a/test/components/LinkButtonTest.js
+++ b/test/components/LinkButtonTest.js
@@ -62,14 +62,22 @@ describe('<LinkButton />', () => {
   });
 
   it('should set active class', () => {
-    const context = { activeMarkupTags: ['a']};
-    const wrapper = shallow(<LinkButton className="keep" />, { context });
-    expect(wrapper).to.have.className('keep');
-    expect(wrapper).to.have.className('active');
+    const wrapper = shallow(<LinkButton className="keep" />);
+    expect(wrapper).to.have.attr('class', 'keep');
+
+    const context = { activeMarkupTags: ['a'] };
+
+    const wrapperActive = shallow(<LinkButton className="keep" />, { context });
+    expect(wrapperActive).to.have.attr('class', 'keep active');
+
+    const wrapperActive2 = shallow(<LinkButton />, { context });
+    expect(wrapperActive2).to.have.attr('class', 'active');
 
     const wrapperCustomActive = shallow(<LinkButton className="keep" activeClassName="aktiv" />, { context });
-    expect(wrapperCustomActive).to.have.className('keep');
-    expect(wrapperCustomActive).to.have.className('aktiv');
+    expect(wrapperCustomActive).to.have.attr('class', 'keep aktiv');
+
+    const wrapperCustomActive2 = shallow(<LinkButton activeClassName="aktiv" />, { context });
+    expect(wrapperCustomActive2).to.have.attr('class', 'aktiv');
   });
 
   it('should accept a custom prompt function', () => {

--- a/test/components/MarkupButtonTest.js
+++ b/test/components/MarkupButtonTest.js
@@ -39,13 +39,21 @@ describe('<MarkupButton />', () => {
   });
 
   it('should set active class', () => {
-    const context = { activeMarkupTags: ['a']};
-    const wrapper = shallow(<MarkupButton tag='A' className="keep" />, { context });
-    expect(wrapper).to.have.className('keep');
-    expect(wrapper).to.have.className('active');
+    const wrapper = shallow(<MarkupButton tag='A' className="keep" />);
+    expect(wrapper).to.have.attr('class', 'keep');
+
+    const context = { activeMarkupTags: ['a'] };
+
+    const wrapperActive = shallow(<MarkupButton tag='A' className="keep" />, { context });
+    expect(wrapperActive).to.have.attr('class', 'keep active');
+
+    const wrapperActive2 = shallow(<MarkupButton tag='A' />, { context });
+    expect(wrapperActive2).to.have.attr('class', 'active');
 
     const wrapperCustomActive = shallow(<MarkupButton tag='A' className="keep" activeClassName="aktiv" />, { context });
-    expect(wrapperCustomActive).to.have.className('keep');
-    expect(wrapperCustomActive).to.have.className('aktiv');
+    expect(wrapperCustomActive).to.have.attr('class', 'keep aktiv');
+
+    const wrapperCustomActive2 = shallow(<MarkupButton tag='A' activeClassName="aktiv" />, { context });
+    expect(wrapperCustomActive2).to.have.attr('class', 'aktiv');
   });
 });

--- a/test/components/SectionButtonTest.js
+++ b/test/components/SectionButtonTest.js
@@ -39,13 +39,21 @@ describe('<SectionButton />', () => {
   });
 
   it('should set active class', () => {
-    const context = { activeSectionTags: ['ul']};
-    const wrapper = shallow(<SectionButton tag='UL' className="keep" />, { context });
-    expect(wrapper).to.have.className('keep');
-    expect(wrapper).to.have.className('active');
+    const wrapper = shallow(<SectionButton tag='UL' className="keep" />);
+    expect(wrapper).to.have.attr('class', 'keep');
+
+    const context = { activeSectionTags: ['ul'] };
+
+    const wrapperActive = shallow(<SectionButton tag='UL' className="keep" />, { context });
+    expect(wrapperActive).to.have.attr('class', 'keep active');
+
+    const wrapperActive2 = shallow(<SectionButton tag='UL' />, { context });
+    expect(wrapperActive2).to.have.attr('class', 'active');
 
     const wrapperCustomActive = shallow(<SectionButton tag='UL' className="keep" activeClassName="aktiv" />, { context });
-    expect(wrapperCustomActive).to.have.className('keep');
-    expect(wrapperCustomActive).to.have.className('aktiv');
+    expect(wrapperCustomActive).to.have.attr('class', 'keep aktiv');
+
+    const wrapperCustomActive2 = shallow(<SectionButton tag='UL' activeClassName="aktiv" />, { context });
+    expect(wrapperCustomActive2).to.have.attr('class', 'aktiv');
   });
 });


### PR DESCRIPTION
We only have 1 internal scenario where we need to join class names.  Drops a dependency and gives a minor speed bump.

I also added more test scenarios.