### PR TITLE
add ability to recreate mobiledoc editor with new mobiledoc data

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -17,7 +17,64 @@ class Container extends React.Component {
 
   constructor() {
     super(...arguments);
+    this.createEditor();
 
+    this.state = {
+      editor: this.editor,
+      activeMarkupTags: [],
+      activeSectionTags: [],
+      activeSectionAttributes: [],
+    };
+  }
+
+  componentWillUnmount() {
+    this.editor.destroy();
+  }
+
+  render() {
+    /* eslint-disable no-unused-vars */
+    /* deconstruct out non-React props before passing to children */
+    const {
+      atoms,
+      autofocus,
+      cardProps,
+      cards,
+      children,
+      didCreateEditor,
+      html,
+      mobiledoc,
+      options,
+      placeholder,
+      serializeVersion,
+      spellcheck,
+      willCreateEditor,
+      onChange,
+      ...componentProps
+    } = this.props;
+    /* eslint-enable no-unused-vars */
+    return (
+      <div {...componentProps}>
+        <ReactMobileDocContext.Provider
+          value={{
+            editor: this.state.editor,
+            activeMarkupTags: this.state.activeMarkupTags,
+            activeSectionTags: this.state.activeSectionTags,
+            activeSectionAttributes: this.state.activeSectionAttributes,
+          }}
+        >
+          {children}
+        </ReactMobileDocContext.Provider>
+      </div>
+    );
+  }
+
+  recreateEditor = () => {
+    this.editor.destroy();
+    this.createEditor();
+    this.setState({ editor: this.editor });
+  };
+
+  createEditor = () => {
     if (typeof this.props.willCreateEditor === 'function') {
       this.props.willCreateEditor();
     }
@@ -57,54 +114,7 @@ class Container extends React.Component {
     if (typeof this.props.didCreateEditor === 'function') {
       this.props.didCreateEditor(this.editor);
     }
-  }
-
-  state = {
-    activeMarkupTags: [],
-    activeSectionTags: [],
-    activeSectionAttributes: [],
   };
-
-  componentWillUnmount() {
-    this.editor.destroy();
-  }
-
-  render() {
-    /* eslint-disable no-unused-vars */
-    /* deconstruct out non-React props before passing to children */
-    const {
-      atoms,
-      autofocus,
-      cardProps,
-      cards,
-      children,
-      didCreateEditor,
-      html,
-      mobiledoc,
-      options,
-      placeholder,
-      serializeVersion,
-      spellcheck,
-      willCreateEditor,
-      onChange,
-      ...componentProps
-    } = this.props;
-    /* eslint-enable no-unused-vars */
-    return (
-      <div {...componentProps}>
-        <ReactMobileDocContext.Provider
-          value={{
-            editor: this.editor,
-            activeMarkupTags: this.state.activeMarkupTags,
-            activeSectionTags: this.state.activeSectionTags,
-            activeSectionAttributes: this.state.activeSectionAttributes,
-          }}
-        >
-          {children}
-        </ReactMobileDocContext.Provider>
-      </div>
-    );
-  }
 
   setActiveTags = () => {
     this.setState({

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -3,9 +3,15 @@ import { ReactMobileDocContext } from './Context';
 
 class Editor extends React.Component {
   componentDidMount() {
+    this.renderMobiledocEditor();
+  }
+
+  componentDidUpdate(previousProps) {
     const { editor } = this.props.context;
-    if (editor) {
-      editor.render(this.editorEl);
+    const { editor: previousEditor } = previousProps.context;
+
+    if (editor !== previousEditor) {
+      this.renderMobiledocEditor();
     }
   }
 
@@ -15,6 +21,13 @@ class Editor extends React.Component {
 
     return <div {...props} ref={(r) => (this.editorEl = r)} />;
   }
+
+  renderMobiledocEditor = () => {
+    const { editor } = this.props.context;
+    if (editor) {
+      editor.render(this.editorEl);
+    }
+  };
 }
 
 const EditorOuter = React.forwardRef(function EditorOuter(props, ref) {


### PR DESCRIPTION
- Container: add createEditor + recreateEditor; add editor to state for rerendering/context usage. 
- Editor: add renderMobiledocEditor. rerender mobiledoc editor when new editor from context arrives