### PR TITLE
Fix toolbar button state bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-mobiledoc-editor",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-mobiledoc-editor",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "prop-types": "^15.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mobiledoc-editor",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "A Mobiledoc editor for React apps",
   "repository": "joshfrench/react-mobiledoc-editor",
   "homepage": "https://github.com/joshfrench/react-mobiledoc-editor",

--- a/src/components/LinkButton.js
+++ b/src/components/LinkButton.js
@@ -26,14 +26,14 @@ const LinkButton = ({
           }
         };
 
-        className = [
+        const currentClassName = [
           className,
           activeMarkupTags.indexOf('a') > -1 && activeClassName,
         ]
           .filter(Boolean)
           .join(' ');
 
-        props = { type, ...props, onClick, className };
+        props = { type, ...props, onClick, className: currentClassName };
         return <button {...props}>{children}</button>;
       }}
     </ReactMobileDocContext.Consumer>

--- a/src/components/MarkupButton.js
+++ b/src/components/MarkupButton.js
@@ -15,13 +15,13 @@ const MarkupButton = ({
     <ReactMobileDocContext.Consumer>
       {({ editor, activeMarkupTags = [] }) => {
         const onClick = () => editor.toggleMarkup(tag);
-        className = [
+        const currentClassName = [
           className,
           activeMarkupTags.indexOf(tag.toLowerCase()) > -1 && activeClassName,
         ]
           .filter(Boolean)
           .join(' ');
-        props = { type, ...props, onClick, className };
+        props = { type, ...props, onClick, className: currentClassName };
         return <button {...props}>{children}</button>;
       }}
     </ReactMobileDocContext.Consumer>

--- a/src/components/SectionButton.js
+++ b/src/components/SectionButton.js
@@ -15,13 +15,13 @@ const SectionButton = ({
     <ReactMobileDocContext.Consumer>
       {({ editor, activeSectionTags = [] }) => {
         const onClick = () => editor.toggleSection(tag);
-        className = [
+        const currentClassName = [
           className,
           activeSectionTags.indexOf(tag.toLowerCase()) > -1 && activeClassName,
         ]
           .filter(Boolean)
           .join(' ');
-        props = { type, ...props, onClick, className };
+        props = { type, ...props, onClick, className: currentClassName };
         return <button {...props}>{children}</button>;
       }}
     </ReactMobileDocContext.Consumer>


### PR DESCRIPTION
The toolbar button state wasn't always correctly updated.
To reproduce, type some letters then bold a few and click in and out of the bold markup text. The bold button state did not turn off when clicking out.  

This was due to reusing the outer-scoped variable which was actually adding "active" multiple times so removing 1 didn't remove all of them. The browser only ever shows 1 but it you log the className you could see "active active active...". The whole component could use a cleanup but wanted to show the minimal fix first.