### PR TITLE
Fix warning in React 18 when unmounting card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-mobiledoc-editor",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-mobiledoc-editor",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "prop-types": "^15.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mobiledoc-editor",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "A Mobiledoc editor for React apps",
   "repository": "joshfrench/react-mobiledoc-editor",
   "homepage": "https://github.com/joshfrench/react-mobiledoc-editor",

--- a/src/utils/react.js
+++ b/src/utils/react.js
@@ -12,6 +12,6 @@ export function reactDomRender(createRoot, element, target) {
 }
 
 export function reactDomUnmount(root, target) {
-  if (root) root.unmount();
+  if (root) root.render(null); // React 18+
   else ReactDOM.unmountComponentAtNode(target);
 }


### PR DESCRIPTION
Render `null` at the card root instead of calling `unmount` in React 18 to fix a warning in dev mode. This is equivalent as it still triggers the necessary lifecycle hooks. Could do it for the <18 unmount too but rather not mess with it as there are no issues with it.